### PR TITLE
fix filepath might never reach the root path

### DIFF
--- a/editorconfig.js
+++ b/editorconfig.js
@@ -30,7 +30,7 @@ function getConfigFileNames(filepath, options) {
   do {
     filepath = path.dirname(filepath);
     paths.push(path.join(filepath, options.config));
-  } while (filepath !== options.root);
+  } while (filepath !== options.root && filepath !== path.dirname(filepath));
   return paths;
 }
 


### PR DESCRIPTION
The `filepath` might never reach root path if the `options.root` is wrong. 

Or in Widows, root is not `/` in file path. Like the problem happen in the editorconfig plugin of Atom here: https://github.com/sindresorhus/atom-editorconfig/issues/19#issuecomment-63010338

So `while` should stop when there's no parent directory.
