### PR TITLE
add promise wrap

### DIFF
--- a/editorconfig.js
+++ b/editorconfig.js
@@ -142,15 +142,19 @@ function readConfigFiles(filepaths) {
 }
 
 module.exports.parseFromFiles = function (filepath, files, options) {
-  filepath = path.resolve(filepath);
-  options = processOptions(options, filepath);
-  return parseFromFiles(filepath, files, options);
+  return new Promise (function (resolve, reject) {
+    filepath = path.resolve(filepath);
+    options = processOptions(options, filepath);
+    return parseFromFiles(filepath, files, options);
+  });
 };
 
 module.exports.parse = function (filepath, options) {
-  filepath = path.resolve(filepath);
-  options = processOptions(options, filepath);
-  var filepaths = getConfigFileNames(filepath, options);
-  var files = readConfigFiles(filepaths);
-  return parseFromFiles(filepath, files, options);
+  return new Promise (function (resolve, reject) {
+    filepath = path.resolve(filepath);
+    options = processOptions(options, filepath);
+    var filepaths = getConfigFileNames(filepath, options);
+    var files = readConfigFiles(filepaths);
+    return parseFromFiles(filepath, files, options);
+  });
 };

--- a/editorconfig.js
+++ b/editorconfig.js
@@ -145,7 +145,7 @@ module.exports.parseFromFiles = function (filepath, files, options) {
   return new Promise (function (resolve, reject) {
     filepath = path.resolve(filepath);
     options = processOptions(options, filepath);
-    return parseFromFiles(filepath, files, options);
+    resolve(parseFromFiles(filepath, files, option));
   });
 };
 
@@ -155,6 +155,6 @@ module.exports.parse = function (filepath, options) {
     options = processOptions(options, filepath);
     var filepaths = getConfigFileNames(filepath, options);
     var files = readConfigFiles(filepaths);
-    return parseFromFiles(filepath, files, options);
+    resolve(parseFromFiles(filepath, files, options));
   });
 };


### PR DESCRIPTION
`parseFromFiles` and `parse` return promise, so how about wrap promise ?  This will catch errors, such as filePath error.