### PR TITLE
Simplify Travis-CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,10 @@
+sudo: false
+
 language: node_js
 
 node_js:
-  - '0.8'
   - '0.10'
   - '0.12'
-
-install:
-  - sudo apt-get install cmake
-  - npm install -g npm
-  - npm install
 
 before_script:
   - npm run pretest


### PR DESCRIPTION
Features:
  - [Use a container-based infrastructure](http://docs.travis-ci.com/user/workers/container-based-infrastructure/) with `sudo: false`
  - Remove `sudo apt-get install cmake`, as it [now comes out-of-the-box with all Travis-CI VMs.](http://docs.travis-ci.com/user/ci-environment/#Compilers-%26-Build-toolchain)
  - Remove `npm install`, since it runs by default.
  - Drop support for Node v0.8. Now that 0.12 is out (0.8 is pretty dated).
  - Build times are almost cut in half.