### PR TITLE
Added parseString to API (fixes #46)

### DIFF
--- a/editorconfig.js
+++ b/editorconfig.js
@@ -235,3 +235,5 @@ module.exports.parseSync = function (filepath, options) {
     var files = readConfigFilesSync(filepaths);
     return parseFromFilesSync(filepath, files, options);
 };
+
+module.exports.parseString = iniparser.parseString;

--- a/test/index.js
+++ b/test/index.js
@@ -82,3 +82,22 @@ describe('parseFromFiles', function() {
     expected.should.eql(editorconfig.parseFromFilesSync(target, configs));
   });
 });
+
+describe('parseString', function() {
+  it('sync', function() {
+    var expected = {
+      indent_style: 'space',
+      indent_size: 2,
+      tab_width: 2,
+      end_of_line: 'lf',
+      charset: 'utf-8',
+      trim_trailing_whitespace: true,
+      insert_final_newline: true,
+    };
+
+    var configPath = path.resolve(__dirname, '../.editorconfig');
+    var contents = fs.readFileSync(configPath, 'utf8');
+
+    expected.should.eql(editorconfig.parseString(contents));
+  });
+});


### PR DESCRIPTION
See #46 for discussion.

Note that this pull request only exposes `parseString` on the public API (matching the documentation). This is the full extent of the changes I would need to make to editorconfig-core-js in order to continue working on my project.