### PR TITLE
Remove `bluebird`.

### DIFF
--- a/bin/editorconfig
+++ b/bin/editorconfig
@@ -2,7 +2,6 @@
 
 var path = require("path");
 var program = require("commander");
-var Promise = require("bluebird");
 
 var editorconfig = require("../editorconfig");
 var package = require("../package.json");

--- a/editorconfig.js
+++ b/editorconfig.js
@@ -3,7 +3,8 @@ var os = require('os');
 var path = require('path');
 var semver = require('semver');
 var util = require('util');
-var whenReadFile = Promise.promisify(fs.readFile);
+var pify = require('pify');
+var whenReadFile = pify(fs.readFile);
 
 var iniparser = require('./lib/ini');
 var minimatch = require('./lib/fnmatch');

--- a/editorconfig.js
+++ b/editorconfig.js
@@ -1,4 +1,3 @@
-var Promise = require('bluebird');
 var fs = require('fs');
 var os = require('os');
 var path = require('path');

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   "author": "EditorConfig Team",
   "license": "MIT",
   "dependencies": {
-    "bluebird": "^3.0.5",
     "commander": "^2.9.0",
     "lru-cache": "^3.2.0",
     "semver": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "commander": "^2.9.0",
     "lru-cache": "^3.2.0",
+    "pify": "^3.0.0",
     "semver": "^5.1.0",
     "sigmund": "^1.0.1"
   },


### PR DESCRIPTION
Promise is native in all versions that will be supported after https://github.com/editorconfig/editorconfig-core-js/issues/40#issuecomment-321327460.  This won't pass Travis on `node@0.10` or `node@0.12`.