### PR TITLE
.travis.yml supports Node 4/6/8. Fixing object shorthand in lib/ini.js.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ language: node_js
 node_js:
   - '0.10'
   - '0.12'
+  - 4
+  - 6
+  - 8
 
 before_script:
   - npm run pretest

--- a/lib/ini.js
+++ b/lib/ini.js
@@ -23,7 +23,7 @@ var regex = {
  * @param: {Function} callback, the function that will be called when parsing is done
  * @return: none
  */
-function parse (file, callback) {
+exports.parse = function (file, callback) {
   if (!callback) {
     return;
   }
@@ -36,11 +36,11 @@ function parse (file, callback) {
   });
 };
 
-function parseSync (file) {
+exports.parseSync = function (file) {
   return parse(fs.readFileSync(file, 'utf8'));
 };
 
-function parseString (data) {
+exports.parseString = function (data) {
   var sectionBody = {};
   var sectionName = null;
   var value = [[sectionName, sectionBody]];
@@ -60,6 +60,4 @@ function parseString (data) {
     }
   });
   return value;
-}
-
-module.exports = { parseString, parseSync, parse };
+};


### PR DESCRIPTION
My hope is that Travis will pass and this could be merged, which would allow @jedmao to cut a minor release (0.13.3) if desired. I'll write another PR later which drops support for 0.10 and 0.12 (which should then be release as 0.14.0 or 1.0.0 when ready).

Edit: Travis passed, yay!