### PR TITLE
Remove IIFE from fnmatch.js

### DIFF
--- a/lib/fnmatch.js
+++ b/lib/fnmatch.js
@@ -1,36 +1,9 @@
 // Based on minimatch.js by isaacs <https://npmjs.org/package/minimatch>
 
-;(function (require, exports, module, platform) {
+  var platform = typeof process === "object" ? process.platform : "win32"
 
   if (module) module.exports = minimatch
   else exports.minimatch = minimatch
-
-  if (!require) {
-    require = function (id) {
-      switch (id) {
-        case "sigmund": return function sigmund (obj) {
-            return JSON.stringify(obj)
-          }
-        case "path": return { basename: function (f) {
-              f = f.split(/[\/\\]/)
-              var e = f.pop()
-              if (!e) e = f.pop()
-              return e
-            }}
-        case "lru-cache": return function LRUCache () {
-            // not quite an LRU, but still space-limited.
-            var cache = {}
-            var cnt = 0
-            this.set = function (k, v) {
-              cnt ++
-              if (cnt >= 100) cache = {}
-              cache[k] = v
-            }
-            this.get = function (k) { return cache[k] }
-          }
-      }
-    }
-  }
 
   minimatch.Minimatch = Minimatch
 
@@ -1072,9 +1045,3 @@
   function regExpEscape (s) {
     return s.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&")
   }
-
-})( typeof require === "function" ? require : null,
-  this,
-    typeof module === "object" ? module : null,
-    typeof process === "object" ? process.platform : "win32"
-)


### PR DESCRIPTION
Hi Jed, I'm trying to add EditorConfig support to [Prettier], but I ran
into a slight issue using [Rollup] to bundle editorconfig:
`lib/fnmatch.js` has an IIFE wrapping the entire file, meaning that
Rollup cannot properly analyze the `require()` calls.

See here for context: https://github.com/prettier/prettier/pull/2760#issuecomment-335015152

Since the IIFE syntax is pretty outdated nowadays, I just removed it. To
keep the initial diff small, I didn't unindent the module body, but I'd
be happy to do that if this looks good otherwise.

[Prettier]: https://prettier.io/
[Rollup]: https://rollupjs.org/