### PR TITLE
remove @types/commander

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   "author": "EditorConfig Team",
   "license": "MIT",
   "dependencies": {
-    "@types/commander": "^2.11.0",
     "@types/semver": "^5.4.0",
     "commander": "^2.11.0",
     "lru-cache": "^4.1.1",


### PR DESCRIPTION
@types/commander@2.12.2: This is a stub types definition for commander (https://github.com/tj/commander.js). commander provides its own type definitions, so you don't need @types/commander installed!