### PR TITLE
Remove david-dm from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # EditorConfig JavaScript Core
 
 [![Build Status](https://travis-ci.org/editorconfig/editorconfig-core-js.svg?branch=master)](https://travis-ci.org/editorconfig/editorconfig-core-js)
-[![dependencies Status](https://david-dm.org/editorconfig/editorconfig-core-js/status.svg)](https://david-dm.org/editorconfig/editorconfig-core-js)
 
 The EditorConfig JavaScript core will provide the same functionality as the
 [EditorConfig C Core][] and [EditorConfig Python Core][].


### PR DESCRIPTION
The `david-dm.org` website is down for 3 months, and the project `alanshaw/david` is not actively maintained anymore. `david-dm.org` should be considered dead, thus badges should be removed from README.