### PR TITLE
Escape real paths for use in minimatch

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -70,6 +70,19 @@ describe('parseFromFiles', () => {
     }])
     cfg.should.eql({ foo: 'null' })
   })
+
+  it('handles minimatch escapables', () => {
+    const bogusPath = '/#?![C] f+ * {foo} (bar|baz)'
+    const escConfigs: editorconfig.ECFile[] = [
+      {
+        name: `${bogusPath}/.editorconfig`,
+        contents: configs[0].contents,
+      },
+    ]
+    const escTarget = `${bogusPath}/app.js`
+    const cfg = editorconfig.parseFromFilesSync(escTarget, escConfigs)
+    cfg.should.eql(expected)
+  })
 })
 
 describe('parseString', () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -72,7 +72,11 @@ describe('parseFromFiles', () => {
   })
 
   it('handles minimatch escapables', () => {
-    const bogusPath = '/#?![C] f+ * {foo} (bar|baz)'
+    // Note that this `#` does not actually test the /^#/ escaping logic,
+    // because this path will go through a `path.dirname` before that happens.
+    // It's here to catch what would happen if minimatch started to treat #
+    // differently inside a pattern.
+    const bogusPath = path.resolve(__dirname, '#?*+@!()|[]{}')
     const escConfigs: editorconfig.ECFile[] = [
       {
         name: `${bogusPath}/.editorconfig`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -207,6 +207,7 @@ function parseFromConfigs(
       .reduce(
         (matches: Props, file) => {
           let pathPrefix = path.dirname(file.name)
+          pathPrefix = pathPrefix.replace(/([|*!+#?{}()[\]])/g, '\\$1')
           if (path.sep !== '/') {
             pathPrefix = pathPrefix.replace(escapedSep, '/')
           }

--- a/src/index.ts
+++ b/src/index.ts
@@ -208,6 +208,13 @@ function parseFromConfigs(
         (matches: Props, file) => {
           let pathPrefix = path.dirname(file.name)
 
+          if (path.sep !== '/') {
+            pathPrefix = pathPrefix.replace(escapedSep, '/')
+          }
+
+          // After Windows path backslash's are turned into slashes, so that
+          // the backslashes we add here aren't turned into forward slashes:
+
           // All of these characters are special to minimatch, but can be
           // forced into path names on many file systems.  Escape them. Note
           // that these are in the order of the case statement in minimatch.
@@ -215,9 +222,7 @@ function parseFromConfigs(
           // I can't think of a way for this to happen in the filesystems I've
           // seen (because of the path.dirname above), but let's be thorough.
           pathPrefix = pathPrefix.replace(/^#/, '\\#')
-          if (path.sep !== '/') {
-            pathPrefix = pathPrefix.replace(escapedSep, '/')
-          }
+
           file.contents.forEach(([glob, options2]) => {
             if (!glob) {
               return

--- a/src/index.ts
+++ b/src/index.ts
@@ -207,7 +207,14 @@ function parseFromConfigs(
       .reduce(
         (matches: Props, file) => {
           let pathPrefix = path.dirname(file.name)
-          pathPrefix = pathPrefix.replace(/([|*!+#?{}()[\]])/g, '\\$1')
+
+          // All of these characters are special to minimatch, but can be
+          // forced into path names on many file systems.  Escape them. Note
+          // that these are in the order of the case statement in minimatch.
+          pathPrefix = pathPrefix.replace(/[?*+@!()|[\]{}]/g, '\\$&')
+          // I can't think of a way for this to happen in the filesystems I've
+          // seen (because of the path.dirname above), but let's be thorough.
+          pathPrefix = pathPrefix.replace(/^#/, '\\#')
           if (path.sep !== '/') {
             pathPrefix = pathPrefix.replace(escapedSep, '/')
           }


### PR DESCRIPTION
Fixes #86.

Can someone check my understanding of what characters minimatch thinks are "special"?  If nobody else gets to it, I'll look at the source tomorrow.  Here is the list I've currently got:

`|*!+#?{}()[\]]`