### PR TITLE
Update semver package 7.3.8 to 7.5.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2147,9 +2147,9 @@
       ]
     },
     "node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },


### PR DESCRIPTION
semver 7.3.8 has vulnerability.

 - https://security.snyk.io/package/npm/semver 
 - https://github.com/advisories/GHSA-c2qf-rxjj-qqgw