### PR TITLE
fix: use minimatch.escape() for path prefix escaping

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "Jed Mao (https://github.com/jedmao/)",
     "Trey Hunner (http://treyhunner.com)",
     "Joe Hildebrand (https://github.com/hildjj/)",
-    "SunsetTechuila (https://github.com/SunsetTechuila/)"
+    "SunsetTechuila (https://github.com/SunsetTechuila/)",
+    "Rex Lorenzo (https://github.com/rlorenzo/)"
   ],
   "directories": {
     "bin": "./bin",
@@ -47,7 +48,7 @@
   "dependencies": {
     "@one-ini/wasm": "0.2.1",
     "commander": "^14.0.3",
-    "minimatch": "10.0.1",
+    "minimatch": "~10.2.4",
     "semver": "^7.7.4"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         specifier: ^14.0.3
         version: 14.0.3
       minimatch:
-        specifier: 10.2.4
+        specifier: ~10.2.4
         version: 10.2.4
       semver:
         specifier: ^7.7.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ importers:
         specifier: ^14.0.3
         version: 14.0.3
       minimatch:
-        specifier: 10.0.1
-        version: 10.0.1
+        specifier: 10.2.4
+        version: 10.2.4
       semver:
         specifier: ^7.7.4
         version: 7.7.4
@@ -341,8 +341,8 @@ packages:
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
 
-  brace-expansion@5.0.3:
-    resolution: {integrity: sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==}
+  brace-expansion@5.0.4:
+    resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
     engines: {node: 18 || 20 || >=22}
 
   browser-stdout@1.3.1:
@@ -748,16 +748,12 @@ packages:
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
-  minimatch@10.0.1:
-    resolution: {integrity: sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==}
-    engines: {node: 20 || >=22}
-
   minimatch@10.2.4:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
     engines: {node: 18 || 20 || >=22}
 
-  minimatch@9.0.8:
-    resolution: {integrity: sha512-reYkDYtj/b19TeqbNZCV4q9t+Yxylf/rYBsLb42SXJatTv4/ylq5lEiAmhA/IToxO7NI2UzNMghHoHuaqDkAjw==}
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   minipass@7.1.3:
@@ -1364,7 +1360,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.3:
+  brace-expansion@5.0.4:
     dependencies:
       balanced-match: 4.0.4
 
@@ -1649,7 +1645,7 @@ snapshots:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
-      minimatch: 9.0.8
+      minimatch: 9.0.9
       minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
@@ -1776,17 +1772,13 @@ snapshots:
 
   mdurl@2.0.0: {}
 
-  minimatch@10.0.1:
-    dependencies:
-      brace-expansion: 2.0.2
-
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.3
+      brace-expansion: 5.0.4
 
-  minimatch@9.0.8:
+  minimatch@9.0.9:
     dependencies:
-      brace-expansion: 5.0.3
+      brace-expansion: 2.0.2
 
   minipass@7.1.3: {}
 
@@ -1803,7 +1795,7 @@ snapshots:
       is-path-inside: 3.0.3
       js-yaml: 4.1.1
       log-symbols: 4.1.0
-      minimatch: 9.0.8
+      minimatch: 9.0.9
       ms: 2.1.3
       picocolors: 1.1.1
       serialize-javascript: 6.0.2
@@ -2006,7 +1998,7 @@ snapshots:
       '@gerrit0/mini-shiki': 3.22.0
       lunr: 2.3.9
       markdown-it: 14.1.1
-      minimatch: 9.0.8
+      minimatch: 9.0.9
       typescript: 5.9.3
       yaml: 2.8.2
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,9 +2,9 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as semver from 'semver';
 
+import {Minimatch, escape} from 'minimatch';
 import {TokenTypes, parse_to_uint32array} from '@one-ini/wasm';
 import {Buffer} from 'node:buffer';
-import {Minimatch} from 'minimatch';
 
 import pkg from '../package.json';
 
@@ -333,16 +333,9 @@ function processFileContents(
       pathPrefix = pathPrefix.replace(escapedSep, '/');
     }
 
-    // After Windows path backslash's are turned into slashes, so that
-    // the backslashes we add here aren't turned into forward slashes:
-
-    // All of these characters are special to minimatch, but can be
-    // forced into path names on many file systems.  Escape them. Note
-    // that these are in the order of the case statement in minimatch.
-    pathPrefix = pathPrefix.replace(/[?*+@!()|[\]{}]/g, '\\$&');
-    // I can't think of a way for this to happen in the filesystems I've
-    // seen (because of the path.dirname above), but let's be thorough.
-    pathPrefix = pathPrefix.replace(/^#/, '\\#');
+    // Use minimatch's escape() with bracket escaping for the path prefix.
+    pathPrefix = escape(pathPrefix, {windowsPathsNoEscape: true});
+    pathPrefix = pathPrefix.replace(/^#/, '[#]');
 
     const globbed: GlobbedProps = parseBuffer(contents).map(([name, body]) => [
       name,


### PR DESCRIPTION
Bump minimatch from 10.0.1 to 10.2.3. Replace manual backslash escaping of path prefixes with minimatch.escape() using bracket-style escaping (windowsPathsNoEscape: true), which avoids a brace-expansion bug that stripped backslash escape sequences.